### PR TITLE
Fix search switch-case for GeneralFeats

### DIFF
--- a/script/motore_ricerca.js
+++ b/script/motore_ricerca.js
@@ -39,7 +39,7 @@ function search(query) {
                         case 'ROLE': url = 'role.php'; break;
                         case 'ArcanaRunes': url = 'arcana_runes.php'; break;
                         case 'RITUALS': url = 'rituals.php'; break;
-                        case 'GenearlFeats': url = 'general_feats.php'; break;
+                        case 'GeneralFeats': url = 'general_feats.php'; break;
                         case 'ClassFeats': url = 'class_feats.php'; break;
                         case 'CoreAbilities': url = 'core_abilities.php'; break;
                         case 'UltimateAbilities': url = 'ultimate_abilities.php'; break;


### PR DESCRIPTION
## Summary
- correct `GeneralFeats` key in the search script

## Testing
- `php -l api/get_weapon.php`
- `php -l api/get_class_path.php`
- `php -l api/get_species.php`
- `php -l api/hello_algolia.php`
- `php -l api/check-login.php`
- `php -l api/logout.php`
- `php -l index.php`
- `php -l homepage.php`
- `php -l login.php`


------
https://chatgpt.com/codex/tasks/task_e_687654b0d1908333acdbab5cda3218ed